### PR TITLE
Added allow_ilm_indices

### DIFF
--- a/manifests/action.pp
+++ b/manifests/action.pp
@@ -111,6 +111,7 @@ define curator::action (
   # $extra_settings = undef, #We don't support $extra_settings yet
   $ignore_empty_list      = 'False',
   $ignore_unavailable     = undef,
+  $allow_ilm_indices      = 'False'
   $include_aliases        = undef,
   $include_global_state   = undef,
   $indices                = undef,

--- a/manifests/action.pp
+++ b/manifests/action.pp
@@ -111,7 +111,7 @@ define curator::action (
   # $extra_settings = undef, #We don't support $extra_settings yet
   $ignore_empty_list      = 'False',
   $ignore_unavailable     = undef,
-  $allow_ilm_indices      = 'False'
+  $allow_ilm_indices      = 'False',
   $include_aliases        = undef,
   $include_global_state   = undef,
   $indices                = undef,

--- a/manifests/action.pp
+++ b/manifests/action.pp
@@ -22,6 +22,10 @@
 #            if anymore, even if an exception is encountered. Curator will log but ignore the exception that was raised.
 #   Default: 'False'
 #
+# [*allow_ilm_indices*]
+#   Boolean. If allow_ilm_indices is set to True, Curator will ingonre all ILM taged Indices and querry them regardless of ILM Polices.            
+#   Default: 'False'
+#
 # [*count*]
 #   Number.  The value for this setting is the number of replicas to assign to matching indices.
 #   Default: undef

--- a/templates/action.erb
+++ b/templates/action.erb
@@ -5,6 +5,7 @@
       continue_if_exception: <%= @continue_if_exception %>
       disable_action: <%= @disable_action %>
       ignore_empty_list: <%= @ignore_empty_list %>
+	  allow_ilm_indices: <%= @allow_ilm_indices %>
 <% if @ignore_unavailable then %>      ignore_unavailable: <%= @ignore_unavailable %>
 <% end -%>
 <% if @allocation_type and ! @post_allocation then %>      allocation_type: <%= @allocation_type %>

--- a/templates/action.erb
+++ b/templates/action.erb
@@ -5,7 +5,7 @@
       continue_if_exception: <%= @continue_if_exception %>
       disable_action: <%= @disable_action %>
       ignore_empty_list: <%= @ignore_empty_list %>
-	  allow_ilm_indices: <%= @allow_ilm_indices %>
+      allow_ilm_indices: <%= @allow_ilm_indices %>
 <% if @ignore_unavailable then %>      ignore_unavailable: <%= @ignore_unavailable %>
 <% end -%>
 <% if @allocation_type and ! @post_allocation then %>      allocation_type: <%= @allocation_type %>


### PR DESCRIPTION
I added the "allow_ilm_indices" option as documented in https://www.elastic.co/guide/en/elasticsearch/client/curator/current/option_allow_ilm.html

It allows curator to handle Indices which are taged with the ILM flag.
In version 6.8 of ELK there is still a bug that tags Indices with the ILM flag, even if its disabled by default in the Elastic output plugin.

The setting was tested with puppet in our env.
And works like a charm.